### PR TITLE
Add initial setup improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+output/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export OPENAI_API_KEY=<your key here>
 To generate synthetic training data, use `LLM-as-a-Judge_Adaptation/Generate_Synthetic_Queries_and_Answers.py`. Replace items in the following command with your dataset and configuration:
 ​
 ````
-python Generate_Synthetic_Queries_and_Answers.py \
+python LLM-as-a-Judge_Adaptation/Generate_Synthetic_Queries_and_Answers.py \
        --document_filepath <document_filepath> \
        --few_shot_prompt_filename <few_shot_prompt_filename> \
        --synthetic_queries_filename <synthetic_queries_filename> \
@@ -47,11 +47,10 @@ python Generate_Synthetic_Queries_and_Answers.py \
 
 Example:
 ````
----
 python LLM-as-a-Judge_Adaptation/Generate_Synthetic_Queries_and_Answers.py \
        --document_filepath example_files/document_filepath.tsv \
        --few_shot_prompt_filename example_files/few_shot_prompt_filename.tsv \
-       --synthetic_queries_filename ./output/synthetic_queries_1.tsv \
+       --synthetic_queries_filename output/synthetic_queries_1.tsv \
        --documents_sampled 10000
 ````
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note: We also allow users to skip Steps #1 and #2 deploying a zero/few-shot LLM-
 To install the necessary dependencies, run the following commands:
 ​
 ````
-conda create -n llm_judge python=3.10
+conda create -n llm_judge python=3.10 --yes
 conda activate llm_judge
 pip install -r requirements.txt
 ````
@@ -42,6 +42,16 @@ python Generate_Synthetic_Queries_and_Answers.py \
        --document_filepath <document_filepath> \
        --few_shot_prompt_filename <few_shot_prompt_filename> \
        --synthetic_queries_filename <synthetic_queries_filename> \
+       --documents_sampled 10000
+````
+
+Example:
+````
+---
+python LLM-as-a-Judge_Adaptation/Generate_Synthetic_Queries_and_Answers.py \
+       --document_filepath example_files/document_filepath.tsv \
+       --few_shot_prompt_filename example_files/few_shot_prompt_filename.tsv \
+       --synthetic_queries_filename ./output/synthetic_queries_1.tsv \
        --documents_sampled 10000
 ````
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -209,12 +209,13 @@ QtPy==2.3.1
 questionary==1.10.0
 rank-bm25==0.2.2
 regex==2023.5.5
+requests==2.31.0
 responses==0.18.0
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rich==13.5.2
-ruamel.yaml==0.17.32
 ruamel.yaml.clib==0.2.7
+ruamel.yaml==0.17.32
 s3transfer==0.6.2
 safetensors==0.3.1
 scikit-learn==1.2.2
@@ -276,4 +277,3 @@ yarl==1.9.2
 zipp==3.15.0
 zlib-state==0.1.5
 zstd==1.5.5.1
-requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -276,3 +276,4 @@ yarl==1.9.2
 zipp==3.15.0
 zlib-state==0.1.5
 zstd==1.5.5.1
+requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -224,7 +224,6 @@ sentence-transformers==2.2.2
 sentencepiece==0.1.99
 sentry-sdk==1.31.0
 setproctitle==1.3.2
-sklearn==0.0.post5
 smart-open==6.3.0
 smmap==5.0.0
 sniffio==1.3.0


### PR DESCRIPTION
## Changes
- Add missing `requests` dependency
- Remove  `sklearn` dependency
  - Why: seems to cause an error and we already have `scikit-learn`?
- Add minor improvements to the README commands

## Testing
I managed to get this far:
```
python LLM-as-a-Judge_Adaptation/Generate_Synthetic_Queries_and_Answers.py \
>        --document_filepath example_files/document_filepath.tsv \
>        --few_shot_prompt_filename example_files/few_shot_prompt_filename.tsv \
>        --synthetic_queries_filename output/synthetic_queries_1.tsv \
>        --documents_sampled 10000
------------------------------------------------------------
Document File: example_files/document_filepath.tsv
Synthetic File Path: output/synthetic_queries_1.tsv
number_of_negatives_added_ratio: 0.5
number_of_positives_added_ratio: 0.0
chosen_score_threshold: 0.01
number_of_contradictory_answers_added_ratio: 0.67
clean_documents: False
question_temperatures: [2.0, 1.5, 1.0, 0.5, 0.0]
percentiles: [0.05, 0.25, 0.5, 0.95]
lower_bound_for_negatives: 20
for_fever_dataset: False
for_wow_dataset: False
------------------------------------------------------------
Loading checkpoint shards: 100%|████████████████████████████████| 5/5 [03:26<00:00, 41.25s/it]
Traceback (most recent call last):
  File "/home/azureuser/ares/ARES/LLM-as-a-Judge_Adaptation/Generate_Synthetic_Queries_and_Answers.py", line 135, in <module>
    model.to(device)
  File "/home/azureuser/miniconda3/envs/llm_judge/lib/python3.10/site-packages/transformers/modeling_utils.py", line 1896, in to
    return super().to(*args, **kwargs)
  File "/home/azureuser/miniconda3/envs/llm_judge/lib/python3.10/site-packages/torch/nn/modules/module.py", line 989, in to
    return self._apply(convert)
  File "/home/azureuser/miniconda3/envs/llm_judge/lib/python3.10/site-packages/torch/nn/modules/module.py", line 641, in _apply
    module._apply(fn)
  File "/home/azureuser/miniconda3/envs/llm_judge/lib/python3.10/site-packages/torch/nn/modules/module.py", line 641, in _apply
    module._apply(fn)
  File "/home/azureuser/miniconda3/envs/llm_judge/lib/python3.10/site-packages/torch/nn/modules/module.py", line 641, in _apply
    module._apply(fn)
  [Previous line repeated 4 more times]
  File "/home/azureuser/miniconda3/envs/llm_judge/lib/python3.10/site-packages/torch/nn/modules/module.py", line 664, in _apply
    param_applied = fn(param)
  File "/home/azureuser/miniconda3/envs/llm_judge/lib/python3.10/site-packages/torch/nn/modules/module.py", line 987, in convert
    return t.to(device, dtype if t.is_floating_point() or t.is_complex() else None, non_blocking)
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 160.00 MiB (GPU 0; 15.77 GiB total capacity; 15.12 GiB already allocated; 95.44 MiB free; 15.12 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```
I'll try again after increasing memory.