### PR TITLE
NQ dataset size in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ wget https://raw.githubusercontent.com/stanford-futuredata/ARES/main/datasets/ex
 wget https://raw.githubusercontent.com/stanford-futuredata/ARES/main/datasets/example_files/nq_unlabeled_output.tsv
 ```
 
-OPTIONAL: You can run the following command to get the full NQ dataset! (347 MB)
+OPTIONAL: You can run the following command to get the full NQ dataset! (37.3 GB)
 ```python
 from ares import ARES
 ares = ARES() 


### PR DESCRIPTION
The size of NQ dataset is actually 37.3 GB?

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/db907cd7-3784-4c61-8b95-e9e26c99ba51">
