### PR TITLE
Solve llm judge training error

### DIFF
--- a/ares/LLM_as_a_Judge_Adaptation/General_Binary_Classifier.py
+++ b/ares/LLM_as_a_Judge_Adaptation/General_Binary_Classifier.py
@@ -403,7 +403,8 @@ def analyze_and_report_data(dataset: str, label_column: str, tokenizer: AutoToke
     synth_queries = synth_queries[synth_queries[label_column] != "NaN"]
     synth_queries = synth_queries[synth_queries["synthetic_query"].notna()]
     synth_queries = synth_queries[synth_queries["document"].notna()]
-    synth_queries = synth_queries[synth_queries['generated_answer'].notna()]
+    if "Context" not in label_column:
+        synth_queries = synth_queries[synth_queries['generated_answer'].notna()]
     synth_queries = synth_queries[synth_queries[label_column].notna()]
 
     # Print count after initial filtering


### PR DESCRIPTION
Do not filer rows without generated answers when training Context Relevance LLM Judge. Not only does this cause only positive samples to be present in the training set, it also causes a (CUDA) error during training because only one label exists.